### PR TITLE
feat: bitcoin scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # sPoX
+
+## Demo flow
+
+sPox can be tested with the sBTC devenv:
+ - `make devenv-up`, wait for nakamoto and `./signers.sh demo` to get the signers ready
+ - Get signers aggregate key with `cargo run -p signer --bin demo-cli info` (from sBTC)
+ - Edit `signer/src/bin/demo_cli.rs`, `exec_deposit` to return after `send_raw_transaction` but before `create_deposit`
+ 
+Now, in no particular order:
+ - Start spox: `cargo run -- -c src/config/default.toml --signers-xonly <signers xonly pubkey from info above>`
+ - Create a deposit (without notifying emily): `cargo run -p signer --bin demo-cli deposit --amount 123456` (from sBTC)
+
+This will look for deposits made to the signers pubkey with the devenv default values. Once the tx is confirmed it should appear on Emily, assuming it didn't expire in the meantime, and be processed by the signers, assuming the amount is not too low to be ignored.

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -1,0 +1,39 @@
+//! Contains functionality for interacting with the Bitcoin blockchain
+
+use bitcoin;
+
+pub mod node;
+
+/// Bitcoin chain tip
+#[derive(Debug, PartialEq, Eq)]
+pub struct BlockRef {
+    /// The height of the block in the bitcoin blockchain.
+    pub block_height: u64,
+    /// Bitcoin block hash. It uniquely identifies the bitcoin block.
+    pub block_hash: bitcoin::BlockHash,
+}
+
+impl std::fmt::Display for BlockRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Block(hash={}, height={})",
+            self.block_hash, self.block_height
+        )
+    }
+}
+
+/// Unspent transaction output
+#[derive(Debug)]
+pub struct Utxo {
+    /// Transaction id
+    pub txid: bitcoin::Txid,
+    /// Output index
+    pub vout: u32,
+    /// The script pubkey of this output
+    pub script_pub_key: bitcoin::ScriptBuf,
+    /// Amount of this output
+    pub amount: bitcoin::Amount,
+    /// Block height of this transaction
+    pub block_height: u64,
+}

--- a/src/bitcoin/node.rs
+++ b/src/bitcoin/node.rs
@@ -1,0 +1,114 @@
+//! Contains client wrappers for bitcoin core
+
+use std::sync::Arc;
+
+use bitcoin::ScriptBuf;
+use bitcoincore_rpc::{Auth, RpcApi};
+use bitcoincore_rpc_json::{GetChainTipsResultStatus, ScanTxOutRequest, Utxo as RpcUtxo};
+use url::Url;
+
+use crate::bitcoin::{BlockRef, Utxo};
+use crate::error::Error;
+
+impl From<RpcUtxo> for Utxo {
+    fn from(value: RpcUtxo) -> Self {
+        Utxo {
+            txid: value.txid,
+            vout: value.vout,
+            script_pub_key: value.script_pub_key,
+            amount: value.amount,
+            block_height: value.height,
+        }
+    }
+}
+
+/// A client for interacting with bitcoin-core
+#[derive(Clone)]
+pub struct BitcoinCoreClient {
+    /// The underlying bitcoin-core client
+    inner: Arc<bitcoincore_rpc::Client>,
+}
+
+/// Implement TryFrom for Url to allow for easy conversion from a URL to a
+/// BitcoinCoreClient.
+impl TryFrom<&Url> for BitcoinCoreClient {
+    type Error = Error;
+
+    fn try_from(url: &Url) -> Result<Self, Self::Error> {
+        let username = url.username().to_string();
+        let password = url.password().unwrap_or_default().to_string();
+        let host = url
+            .host_str()
+            .ok_or(Error::InvalidUrl(url::ParseError::EmptyHost))?;
+        let port = url.port().ok_or(Error::PortRequired)?;
+
+        let endpoint = format!("{}://{host}:{port}", url.scheme());
+
+        Self::new(&endpoint, username, password)
+    }
+}
+
+impl BitcoinCoreClient {
+    /// Return a bitcoin-core RPC client. Will error if the URL is an invalid URL.
+    pub fn new(url: &str, username: String, password: String) -> Result<Self, Error> {
+        let auth = Auth::UserPass(username, password);
+        let client = bitcoincore_rpc::Client::new(url, auth)
+            .map_err(|err| Error::BitcoinCoreRpcClient(err, url.to_string()))?;
+
+        Ok(Self { inner: Arc::new(client) })
+    }
+
+    /// Get the canonical chain tip
+    pub fn get_chain_tip(&self) -> Result<BlockRef, Error> {
+        let result = self
+            .inner
+            .get_chain_tips()
+            .map_err(Error::BitcoinCoreRpc)?
+            .into_iter()
+            .find(|tip| tip.status == GetChainTipsResultStatus::Active)
+            .ok_or(Error::NoChainTip)?;
+
+        Ok(BlockRef {
+            block_hash: result.hash,
+            block_height: result.height,
+        })
+    }
+
+    /// Get UTXOs for addresses
+    /// TODO: change `addresses` to an iterator
+    pub fn get_utxos(&self, addresses: &[ScriptBuf]) -> Result<Vec<Utxo>, Error> {
+        let descriptors = addresses
+            .iter()
+            .map(|addr| ScanTxOutRequest::Single(format!("raw({})", addr.to_hex_string())))
+            .collect::<Vec<_>>();
+
+        let result = self
+            .inner
+            .scan_tx_out_set_blocking(&descriptors)
+            .map_err(Error::BitcoinCoreRpc)?;
+
+        if result.success != Some(true) {
+            return Err(Error::ScanTxOutFailure);
+        }
+
+        Ok(result.unspents.into_iter().map(Into::into).collect())
+    }
+
+    /// Get the canonical block hash for a given block height
+    pub fn get_block_hash(&self, block_height: u64) -> Result<bitcoin::BlockHash, Error> {
+        self.inner
+            .get_block_hash(block_height)
+            .map_err(Error::BitcoinCoreRpc)
+    }
+
+    /// Get the transaction hex
+    pub fn get_raw_transaction_hex(
+        &self,
+        txid: &bitcoin::Txid,
+        block_hash: &bitcoin::BlockHash,
+    ) -> Result<String, Error> {
+        self.inner
+            .get_raw_transaction_hex(txid, Some(block_hash))
+            .map_err(Error::BitcoinCoreRpc)
+    }
+}

--- a/src/bitcoin/node.rs
+++ b/src/bitcoin/node.rs
@@ -75,10 +75,12 @@ impl BitcoinCoreClient {
     }
 
     /// Get UTXOs for addresses
-    /// TODO: change `addresses` to an iterator
-    pub fn get_utxos(&self, addresses: &[ScriptBuf]) -> Result<Vec<Utxo>, Error> {
+    pub fn get_utxos<'a, I>(&self, addresses: I) -> Result<Vec<Utxo>, Error>
+    where
+        I: IntoIterator<Item = &'a ScriptBuf>,
+    {
         let descriptors = addresses
-            .iter()
+            .into_iter()
             .map(|addr| ScanTxOutRequest::Single(format!("raw({})", addr.to_hex_string())))
             .collect::<Vec<_>>();
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,49 @@
+//! Application context
+
+use std::sync::Arc;
+
+use emily_client::apis::configuration::Configuration as EmilyConfig;
+
+use crate::bitcoin::node::BitcoinCoreClient;
+use crate::config::Settings;
+use crate::error::Error;
+
+/// Application context
+#[derive(Clone)]
+pub struct Context {
+    bitcoin_client: BitcoinCoreClient,
+    emily_config: Arc<EmilyConfig>,
+}
+
+impl TryFrom<&Settings> for Context {
+    type Error = Error;
+
+    fn try_from(value: &Settings) -> Result<Self, Self::Error> {
+        let bitcoin_client = BitcoinCoreClient::try_from(&value.bitcoin_rpc_endpoint)?;
+        let emily_config = EmilyConfig {
+            base_path: value
+                .emily_endpoint
+                .to_string()
+                .trim_end_matches('/')
+                .to_string(),
+            ..Default::default()
+        };
+
+        Ok(Self {
+            bitcoin_client,
+            emily_config: Arc::new(emily_config),
+        })
+    }
+}
+
+impl Context {
+    /// Get a reference to the Bitcoin client
+    pub fn bitcoin_client(&self) -> &BitcoinCoreClient {
+        &self.bitcoin_client
+    }
+
+    /// Get a reference to the Emily config
+    pub fn emily_config(&self) -> &EmilyConfig {
+        &self.emily_config
+    }
+}

--- a/src/deposit_monitor.rs
+++ b/src/deposit_monitor.rs
@@ -1,0 +1,123 @@
+//! Module to monitor for pending deposits
+
+use std::collections::HashMap;
+
+use bitcoin::ScriptBuf;
+use emily_client::models::CreateDepositRequestBody;
+use sbtc::deposits::{DepositScriptInputs, ReclaimScriptInputs};
+
+use crate::bitcoin::{BlockRef, Utxo};
+use crate::context::Context;
+use crate::error::Error;
+
+/// A deposit address to monitor
+pub struct MonitoredDeposit {
+    /// Deposit script inputs
+    pub deposit_script_inputs: DepositScriptInputs,
+    /// Reclaim script inputs
+    pub reclaim_script_inputs: ReclaimScriptInputs,
+}
+
+impl MonitoredDeposit {
+    /// Get the scriptPubKey for this deposit address
+    pub fn to_script_pubkey(&self) -> ScriptBuf {
+        sbtc::deposits::to_script_pubkey(
+            self.deposit_script_inputs.deposit_script(),
+            self.reclaim_script_inputs.reclaim_script(),
+        )
+    }
+}
+
+/// Deposit monitor
+pub struct DepositMonitor {
+    context: Context,
+    monitored: HashMap<ScriptBuf, MonitoredDeposit>,
+}
+
+impl DepositMonitor {
+    /// Creates a new `DepositMonitor`
+    pub fn new(context: Context, monitored: Vec<MonitoredDeposit>) -> Self {
+        let monitored = monitored
+            .into_iter()
+            .map(|m| (m.to_script_pubkey(), m))
+            .collect();
+        Self { context, monitored }
+    }
+
+    /// Process a `Utxo` to get a create deposit request for Emily
+    pub fn get_deposit_from_utxo(
+        &self,
+        utxo: &Utxo,
+        chain_tip: &BlockRef,
+    ) -> Result<CreateDepositRequestBody, Error> {
+        let monitored_deposit = self
+            .monitored
+            .get(&utxo.script_pub_key)
+            .ok_or_else(|| Error::MissingMonitoredDeposit(utxo.script_pub_key.clone()))?;
+
+        let unlocking_time =
+            utxo.block_height + (monitored_deposit.reclaim_script_inputs.lock_time() as u64);
+        if unlocking_time <= chain_tip.block_height {
+            return Err(Error::DepositExpired);
+        }
+
+        let bitcoin_client = self.context.bitcoin_client();
+
+        // TODO: cache results
+        let block_hash = bitcoin_client.get_block_hash(utxo.block_height)?;
+
+        // TODO: cache results
+        let tx_hex = bitcoin_client.get_raw_transaction_hex(&utxo.txid, &block_hash)?;
+
+        Ok(CreateDepositRequestBody {
+            bitcoin_tx_output_index: utxo.vout,
+            bitcoin_txid: utxo.txid.to_string(),
+            deposit_script: monitored_deposit
+                .deposit_script_inputs
+                .deposit_script()
+                .to_hex_string(),
+            reclaim_script: monitored_deposit
+                .reclaim_script_inputs
+                .reclaim_script()
+                .to_hex_string(),
+            transaction_hex: tx_hex,
+        })
+    }
+
+    /// Check pending deposits confirmed to the monitored addresses
+    pub fn get_pending_deposits(
+        &self,
+        chain_tip: &BlockRef,
+    ) -> Result<Vec<CreateDepositRequestBody>, Error> {
+        let utxos = self
+            .context
+            .bitcoin_client()
+            .get_utxos(self.monitored.keys())?;
+
+        let create_deposits = utxos
+            .iter()
+            .flat_map(|utxo| {
+                self.get_deposit_from_utxo(utxo, chain_tip)
+                    .inspect_err(|error| match error {
+                        Error::DepositExpired => tracing::info!(
+                            %error,
+                            txid = %utxo.txid,
+                            vout = %utxo.vout,
+                            block_height = %utxo.block_height,
+                            "deposit is expired; skipping utxo"
+                        ),
+                        _ => tracing::warn!(
+                            %error,
+                            txid = %utxo.txid,
+                            vout = %utxo.vout,
+                            block_height = %utxo.block_height,
+                            "failed to get deposit from utxo; skipping utxo"
+                        ),
+                    })
+                    .ok()
+            })
+            .collect();
+
+        Ok(create_deposits)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,29 @@
+//! Top-level error type
+
+/// Top-level application error
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Error from the Bitcoin RPC client.
+    #[error("bitcoin RPC error: {0}")]
+    BitcoinCoreRpc(#[from] bitcoincore_rpc::Error),
+
+    /// Error when creating an RPC client to bitcoin-core
+    #[error("could not create RPC client to {1}: {0}")]
+    BitcoinCoreRpcClient(#[source] bitcoincore_rpc::Error, String),
+
+    /// Error when parsing a URL
+    #[error("could not parse the provided URL: {0}")]
+    InvalidUrl(#[source] url::ParseError),
+
+    /// No chain tip found.
+    #[error("no bitcoin chain tip")]
+    NoChainTip,
+
+    /// Error when the port is not provided
+    #[error("a port must be specified")]
+    PortRequired,
+
+    /// A call to `scantxoutset` failed
+    #[error("a call to `scantxoutset` failed")]
+    ScanTxOutFailure,
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 //! Top-level error type
 
+use bitcoin::ScriptBuf;
+
 /// Top-level application error
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -11,6 +13,10 @@ pub enum Error {
     #[error("could not create RPC client to {1}: {0}")]
     BitcoinCoreRpcClient(#[source] bitcoincore_rpc::Error, String),
 
+    /// The pending deposit is expired
+    #[error("the pending deposit is expired")]
+    DepositExpired,
+
     /// Error when parsing a URL
     #[error("could not parse the provided URL: {0}")]
     InvalidUrl(#[source] url::ParseError),
@@ -18,6 +24,10 @@ pub enum Error {
     /// No chain tip found.
     #[error("no bitcoin chain tip")]
     NoChainTip,
+
+    /// Missing monitored deposit address for scriptPubKey
+    #[error("missing monitored deposit address for scriptPubKey {0}")]
+    MissingMonitoredDeposit(ScriptBuf),
 
     /// Error when the port is not provided
     #[error("a port must be specified")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 
 pub mod bitcoin;
 pub mod config;
+pub mod context;
+pub mod deposit_monitor;
 pub mod error;
 pub mod logging;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
 
+pub mod bitcoin;
 pub mod config;
+pub mod error;
 pub mod logging;
 
 #[cfg(any(test, feature = "testing"))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tracing::error!(%error, "failed to construct the configuration");
     })?;
 
-    dbg!(config);
+    // TODO: remove, demo code
+    let bitcoin_client =
+        spox::bitcoin::node::BitcoinCoreClient::try_from(&config.bitcoin_rpc_endpoint)?;
+    dbg!(bitcoin_client.get_chain_tip().unwrap());
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,17 @@
 use std::path::PathBuf;
+use std::str::FromStr;
+use std::time::Duration;
 
+use bitcoin::{ScriptBuf, secp256k1};
 use clap::{Parser, ValueEnum};
+use clarity::vm::types::PrincipalData;
+use emily_client::apis::deposit_api;
+use sbtc::deposits::{DepositScriptInputs, ReclaimScriptInputs};
+use spox::bitcoin::BlockRef;
 use spox::config::Settings;
+use spox::context::Context;
+use spox::deposit_monitor::{DepositMonitor, MonitoredDeposit};
+use spox::error::Error;
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
 enum LogOutputFormat {
@@ -20,6 +30,100 @@ struct Args {
 
     #[clap(short = 'o', long = "output-format", default_value = "pretty")]
     output_format: LogOutputFormat,
+
+    /// TODO: remove once config is ready
+    #[clap(long = "signers-xonly")]
+    signers_xonly: String,
+}
+
+async fn fetch_and_create_deposits(
+    context: &Context,
+    deposit_monitor: &DepositMonitor,
+    chain_tip: &BlockRef,
+) -> Result<(), Error> {
+    let emily_config = context.emily_config();
+
+    let deposits = deposit_monitor.get_pending_deposits(chain_tip)?;
+
+    tracing::debug!(count = deposits.len(), "fetched pending deposits");
+    if deposits.is_empty() {
+        return Ok(());
+    }
+
+    for deposit in deposits {
+        // TODO: emily will nop for duplicates, but we shouldn't send them
+        if let Err(error) = deposit_api::create_deposit(emily_config, deposit.clone()).await {
+            tracing::warn!(
+                %error,
+                txid = %deposit.bitcoin_txid,
+                vout = %deposit.bitcoin_tx_output_index,
+                "cannot create deposit in emily"
+            );
+        } else {
+            tracing::info!(
+                txid = %deposit.bitcoin_txid,
+                vout = %deposit.bitcoin_tx_output_index,
+                "created deposit in emily"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+async fn runloop(context: Context, deposit_monitor: &DepositMonitor, polling_interval: Duration) {
+    let bitcoin_client = context.bitcoin_client();
+    let mut last_chain_tip = None;
+
+    loop {
+        if last_chain_tip.is_some() {
+            tokio::time::sleep(polling_interval).await;
+        }
+
+        let chain_tip = match bitcoin_client.get_chain_tip() {
+            Ok(chain_tip) => chain_tip,
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "error getting the chain tip"
+                );
+                continue;
+            }
+        };
+
+        let is_last_chaintip = last_chain_tip
+            .as_ref()
+            .is_some_and(|last| last == &chain_tip);
+
+        if is_last_chaintip {
+            continue;
+        }
+
+        tracing::debug!(%chain_tip, "new block; processing pending deposits");
+
+        let _ = fetch_and_create_deposits(&context, deposit_monitor, &chain_tip)
+            .await
+            .inspect_err(|error| {
+                tracing::warn!(
+                    %error,
+                    "error processing pending deposits"
+                )
+            });
+
+        last_chain_tip = Some(chain_tip);
+    }
+}
+
+fn devenv_deposit_address(signers_xonly: &str) -> MonitoredDeposit {
+    MonitoredDeposit {
+        deposit_script_inputs: DepositScriptInputs {
+            signers_public_key: secp256k1::XOnlyPublicKey::from_str(signers_xonly).unwrap(),
+            recipient: PrincipalData::parse("ST3497E9JFQ7KB9VEHAZRWYKF3296WQZEXBPXG193").unwrap(),
+            max_fee: 20000,
+        },
+        reclaim_script_inputs: ReclaimScriptInputs::try_new(10, ScriptBuf::from_hex("").unwrap())
+            .unwrap(),
+    }
 }
 
 #[tokio::main]
@@ -37,10 +141,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tracing::error!(%error, "failed to construct the configuration");
     })?;
 
-    // TODO: remove, demo code
-    let bitcoin_client =
-        spox::bitcoin::node::BitcoinCoreClient::try_from(&config.bitcoin_rpc_endpoint)?;
-    dbg!(bitcoin_client.get_chain_tip().unwrap());
+    let context = Context::try_from(&config)?;
+
+    // TODO: load from config
+    let monitored = vec![devenv_deposit_address(&args.signers_xonly)];
+
+    let deposit_monitor = DepositMonitor::new(context.clone(), monitored);
+
+    runloop(context.clone(), &deposit_monitor, config.polling_interval).await;
 
     Ok(())
 }


### PR DESCRIPTION
Add bitcoin node client, and the rpc calls required to run the demo flow:
 - `get_chain_tip` to check for expired deposits and skipping already processed chain tips
 - `get_utxos` to get the UTXOs of the monitored addresses, via `scantxoutset`
 - `get_block_hash` + `get_raw_transaction_hex` to get the tx hex required to create the deposit on Emily

I haven't tested the performances of `scantxoutset` on a "real" network yet, but assuming is not too bad this should work with a non-indexed node, eventually even a pruned one -- you would not be able to submit deposits for pruned blocks, but assuming a non too aggressive pruning it should be fine.

We could abstract those 4 and enable using a mempool instance instead of a bitcoin node, since we can:
 - `/api/blocks/tip/height` (+ `/api/blocks/tip/hash`)
 - `/api/address/:address/utxo`
 - `/api/block-height/:height` + `/api/tx/:txid/hex`
but since this is a PoC I wanted to keep it as slim as possible.