### PR TITLE
feat: deposit monitor scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # sPoX
+
+## Demo flow
+
+sPox can be tested with the sBTC devenv:
+ - `make devenv-up`, wait for nakamoto and `./signers.sh demo` to get the signers ready
+ - Get signers aggregate key with `cargo run -p signer --bin demo-cli info` (from sBTC)
+ - Edit `signer/src/bin/demo_cli.rs`, `exec_deposit` to return after `send_raw_transaction` but before `create_deposit`
+ 
+Now, in no particular order:
+ - Start spox: `cargo run -- -c src/config/default.toml --signers-xonly <signers xonly pubkey from info above>`
+ - Create a deposit (without notifying emily): `cargo run -p signer --bin demo-cli deposit --amount 123456` (from sBTC)
+
+This will look for deposits made to the signers pubkey with the devenv default values. Once the tx is confirmed it should appear on Emily, assuming it didn't expire in the meantime, and be processed by the signers, assuming the amount is not too low to be ignored.

--- a/src/bitcoin/node.rs
+++ b/src/bitcoin/node.rs
@@ -75,10 +75,12 @@ impl BitcoinCoreClient {
     }
 
     /// Get UTXOs for addresses
-    /// TODO: change `addresses` to an iterator
-    pub fn get_utxos(&self, addresses: &[ScriptBuf]) -> Result<Vec<Utxo>, Error> {
+    pub fn get_utxos<'a, I>(&self, addresses: I) -> Result<Vec<Utxo>, Error>
+    where
+        I: IntoIterator<Item = &'a ScriptBuf>,
+    {
         let descriptors = addresses
-            .iter()
+            .into_iter()
             .map(|addr| ScanTxOutRequest::Single(format!("raw({})", addr.to_hex_string())))
             .collect::<Vec<_>>();
 

--- a/src/deposit_monitor.rs
+++ b/src/deposit_monitor.rs
@@ -1,0 +1,123 @@
+//! Module to monitor for pending deposits
+
+use std::collections::HashMap;
+
+use bitcoin::ScriptBuf;
+use emily_client::models::CreateDepositRequestBody;
+use sbtc::deposits::{DepositScriptInputs, ReclaimScriptInputs};
+
+use crate::bitcoin::{BlockRef, Utxo};
+use crate::context::Context;
+use crate::error::Error;
+
+/// A deposit address to monitor
+pub struct MonitoredDeposit {
+    /// Deposit script inputs
+    pub deposit_script_inputs: DepositScriptInputs,
+    /// Reclaim script inputs
+    pub reclaim_script_inputs: ReclaimScriptInputs,
+}
+
+impl MonitoredDeposit {
+    /// Get the scriptPubKey for this deposit address
+    pub fn to_script_pubkey(&self) -> ScriptBuf {
+        sbtc::deposits::to_script_pubkey(
+            self.deposit_script_inputs.deposit_script(),
+            self.reclaim_script_inputs.reclaim_script(),
+        )
+    }
+}
+
+/// Deposit monitor
+pub struct DepositMonitor {
+    context: Context,
+    monitored: HashMap<ScriptBuf, MonitoredDeposit>,
+}
+
+impl DepositMonitor {
+    /// Creates a new `DepositMonitor`
+    pub fn new(context: Context, monitored: Vec<MonitoredDeposit>) -> Self {
+        let monitored = monitored
+            .into_iter()
+            .map(|m| (m.to_script_pubkey(), m))
+            .collect();
+        Self { context, monitored }
+    }
+
+    /// Process a `Utxo` to get a create deposit request for Emily
+    pub fn get_deposit_from_utxo(
+        &self,
+        utxo: &Utxo,
+        chain_tip: &BlockRef,
+    ) -> Result<CreateDepositRequestBody, Error> {
+        let monitored_deposit = self
+            .monitored
+            .get(&utxo.script_pub_key)
+            .ok_or_else(|| Error::MissingMonitoredDeposit(utxo.script_pub_key.clone()))?;
+
+        let unlocking_time =
+            utxo.block_height + (monitored_deposit.reclaim_script_inputs.lock_time() as u64);
+        if unlocking_time <= chain_tip.block_height {
+            return Err(Error::DepositExpired);
+        }
+
+        let bitcoin_client = self.context.bitcoin_client();
+
+        // TODO: cache results
+        let block_hash = bitcoin_client.get_block_hash(utxo.block_height)?;
+
+        // TODO: cache results
+        let tx_hex = bitcoin_client.get_raw_transaction_hex(&utxo.txid, &block_hash)?;
+
+        Ok(CreateDepositRequestBody {
+            bitcoin_tx_output_index: utxo.vout,
+            bitcoin_txid: utxo.txid.to_string(),
+            deposit_script: monitored_deposit
+                .deposit_script_inputs
+                .deposit_script()
+                .to_hex_string(),
+            reclaim_script: monitored_deposit
+                .reclaim_script_inputs
+                .reclaim_script()
+                .to_hex_string(),
+            transaction_hex: tx_hex,
+        })
+    }
+
+    /// Check pending deposits confirmed to the monitored addresses
+    pub fn get_pending_deposits(
+        &self,
+        chain_tip: &BlockRef,
+    ) -> Result<Vec<CreateDepositRequestBody>, Error> {
+        let utxos = self
+            .context
+            .bitcoin_client()
+            .get_utxos(self.monitored.keys())?;
+
+        let create_deposits = utxos
+            .iter()
+            .flat_map(|utxo| {
+                self.get_deposit_from_utxo(utxo, chain_tip)
+                    .inspect_err(|error| match error {
+                        Error::DepositExpired => tracing::trace!(
+                            %error,
+                            txid = %utxo.txid,
+                            vout = %utxo.vout,
+                            block_height = %utxo.block_height,
+                            "deposit is expired; skipping utxo"
+                        ),
+                        _ => tracing::warn!(
+                            %error,
+                            txid = %utxo.txid,
+                            vout = %utxo.vout,
+                            block_height = %utxo.block_height,
+                            "failed to get deposit from utxo; skipping utxo"
+                        ),
+                    })
+                    .ok()
+            })
+            .collect();
+
+        Ok(create_deposits)
+    }
+}

--- a/src/deposit_monitor.rs
+++ b/src/deposit_monitor.rs
@@ -99,7 +99,7 @@ impl DepositMonitor {
             .flat_map(|utxo| {
                 self.get_deposit_from_utxo(utxo, chain_tip)
                     .inspect_err(|error| match error {
-                        Error::DepositExpired => tracing::trace!(
+                        Error::DepositExpired => tracing::info!(
                             %error,
                             txid = %utxo.txid,
                             vout = %utxo.vout,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 //! Top-level error type
 
+use bitcoin::ScriptBuf;
+
 /// Top-level application error
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -11,6 +13,10 @@ pub enum Error {
     #[error("could not create RPC client to {1}: {0}")]
     BitcoinCoreRpcClient(#[source] bitcoincore_rpc::Error, String),
 
+    /// The pending deposit is expired
+    #[error("the pending deposit is expired")]
+    DepositExpired,
+
     /// Error when parsing a URL
     #[error("could not parse the provided URL: {0}")]
     InvalidUrl(#[source] url::ParseError),
@@ -18,6 +24,10 @@ pub enum Error {
     /// No chain tip found.
     #[error("no bitcoin chain tip")]
     NoChainTip,
+
+    /// Missing monitored deposit address for scriptPubKey
+    #[error("missing monitored deposit address for scriptPubKey {0}")]
+    MissingMonitoredDeposit(ScriptBuf),
 
     /// Error when the port is not provided
     #[error("a port must be specified")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod bitcoin;
 pub mod config;
 pub mod context;
+pub mod deposit_monitor;
 pub mod error;
 pub mod logging;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,10 +91,11 @@ async fn runloop(context: Context, deposit_monitor: &DepositMonitor, polling_int
             }
         };
 
-        if last_chain_tip
+        let is_last_chaintip = last_chain_tip
             .as_ref()
-            .is_some_and(|last| last == &chain_tip)
-        {
+            .is_some_and(|last| last == &chain_tip);
+
+        if is_last_chaintip {
             continue;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,17 @@
 use std::path::PathBuf;
+use std::str::FromStr;
+use std::time::Duration;
 
+use bitcoin::{ScriptBuf, secp256k1};
 use clap::{Parser, ValueEnum};
+use clarity::vm::types::PrincipalData;
+use emily_client::apis::deposit_api;
+use sbtc::deposits::{DepositScriptInputs, ReclaimScriptInputs};
+use spox::bitcoin::BlockRef;
 use spox::config::Settings;
 use spox::context::Context;
+use spox::deposit_monitor::{DepositMonitor, MonitoredDeposit};
+use spox::error::Error;
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
 enum LogOutputFormat {
@@ -21,6 +30,99 @@ struct Args {
 
     #[clap(short = 'o', long = "output-format", default_value = "pretty")]
     output_format: LogOutputFormat,
+
+    /// TODO: remove once config is ready
+    #[clap(long = "signers-xonly")]
+    signers_xonly: String,
+}
+
+async fn fetch_and_create_deposits(
+    context: &Context,
+    deposit_monitor: &DepositMonitor,
+    chain_tip: &BlockRef,
+) -> Result<(), Error> {
+    let emily_config = context.emily_config();
+
+    let deposits = deposit_monitor.get_pending_deposits(chain_tip)?;
+
+    tracing::debug!(count = deposits.len(), "fetched pending deposits");
+    if deposits.is_empty() {
+        return Ok(());
+    }
+
+    for deposit in deposits {
+        // TODO: emily will nop for duplicates, but we shouldn't send them
+        if let Err(error) = deposit_api::create_deposit(emily_config, deposit.clone()).await {
+            tracing::warn!(
+                %error,
+                txid = %deposit.bitcoin_txid,
+                vout = %deposit.bitcoin_tx_output_index,
+                "cannot create deposit in emily"
+            );
+        } else {
+            tracing::info!(
+                txid = %deposit.bitcoin_txid,
+                vout = %deposit.bitcoin_tx_output_index,
+                "created deposit in emily"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+async fn runloop(context: Context, deposit_monitor: &DepositMonitor, polling_interval: Duration) {
+    let bitcoin_client = context.bitcoin_client();
+    let mut last_chain_tip = None;
+
+    loop {
+        if last_chain_tip.is_some() {
+            tokio::time::sleep(polling_interval).await;
+        }
+
+        let chain_tip = match bitcoin_client.get_chain_tip() {
+            Ok(chain_tip) => chain_tip,
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "error getting the chain tip"
+                );
+                continue;
+            }
+        };
+
+        if last_chain_tip
+            .as_ref()
+            .is_some_and(|last| last == &chain_tip)
+        {
+            continue;
+        }
+
+        tracing::debug!(%chain_tip, "new block; processing pending deposits");
+
+        let _ = fetch_and_create_deposits(&context, deposit_monitor, &chain_tip)
+            .await
+            .inspect_err(|error| {
+                tracing::warn!(
+                    %error,
+                    "error processing pending deposits"
+                )
+            });
+
+        last_chain_tip = Some(chain_tip);
+    }
+}
+
+fn devenv_deposit_address(signers_xonly: &str) -> MonitoredDeposit {
+    MonitoredDeposit {
+        deposit_script_inputs: DepositScriptInputs {
+            signers_public_key: secp256k1::XOnlyPublicKey::from_str(signers_xonly).unwrap(),
+            recipient: PrincipalData::parse("ST3497E9JFQ7KB9VEHAZRWYKF3296WQZEXBPXG193").unwrap(),
+            max_fee: 20000,
+        },
+        reclaim_script_inputs: ReclaimScriptInputs::try_new(10, ScriptBuf::from_hex("").unwrap())
+            .unwrap(),
+    }
 }
 
 #[tokio::main]
@@ -38,10 +140,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tracing::error!(%error, "failed to construct the configuration");
     })?;
 
-    // TODO: remove, demo code
     let context = Context::try_from(&config)?;
-    dbg!(context.bitcoin_client().get_chain_tip()?);
-    dbg!(emily_client::apis::limits_api::get_limits(context.emily_config()).await?);
+
+    // TODO: load from config
+    let monitored = vec![devenv_deposit_address(&args.signers_xonly)];
+
+    let deposit_monitor = DepositMonitor::new(context.clone(), monitored);
+
+    runloop(context.clone(), &deposit_monitor, config.polling_interval).await;
 
     Ok(())
 }


### PR DESCRIPTION
Last scaffolding bit: deposit monitoring and runloop.

There are basically no tests, but can be tested with sBTC devenv (via a manual deposit, I'll check with pox payments later):
 - Usual `make devenv-up`, wait for nakamoto and `./signers.sh demo` for donation+sanity check
 - Get signers aggregate key with `cargo run -p signer --bin demo-cli info`
 - Edit `signer/src/bin/demo_cli.rs`, `exec_deposit` to return after `send_raw_transaction` but before `create_deposit`
 
Now, in no particular order:
 - Start spox: `cargo run -- -c src/config/default.toml --signers-xonly <signers xonly pubkey from info above>`
 - Create a deposit (without notifying emily): `cargo run -p signer --bin demo-cli deposit --amount 123456`

This will look for deposits made to the signers pubkey with the devenv default values. Once the tx is confirmed it should appear on Emily, assuming it didn't expire in the meantime, and be processed by the signers, assuming the amount is not too low to be ignored.