### PR TITLE
[chore]: cache bitcoin client results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,6 +1334,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "lru"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ea4e65087ff52f3862caff188d489f1fab49a0cb09e01b2e3f1a617b10aaed"
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2336,6 +2342,7 @@ dependencies = [
  "clarity",
  "config",
  "emily-client",
+ "lru",
  "sbtc",
  "serde",
  "test-case",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { version = "1.43.0", default-features = false, features = ["signal", "m
 tracing = { version = "0.1.41", default-features = false, features = ["attributes"]}
 tracing-subscriber = { version = "0.3.19", default-features = false, features = ["env-filter", "fmt", "json", "time", "ansi"] }
 url = { version = "2.5.4", default-features = false }
+lru = {version = "0.16.0", default-features = false }
 
 [dev-dependencies]
 testing-emily-client = { git = "https://github.com/stacks-sbtc/sbtc.git", rev = "02e91d911659c257db686d4fc7c821342b87d655", default-features = false }

--- a/src/deposit_monitor.rs
+++ b/src/deposit_monitor.rs
@@ -93,7 +93,7 @@ impl DepositMonitor {
                     hash
                 );
                 *hash
-            },
+            }
             None => {
                 tracing::debug!(
                     "Fetching block hash for utxo at height {}",
@@ -114,7 +114,7 @@ impl DepositMonitor {
                     block_hash
                 );
                 hex.clone()
-            },
+            }
             None => {
                 tracing::debug!(
                     "Fetching transaction hex for txid {} at block {}",

--- a/src/deposit_monitor.rs
+++ b/src/deposit_monitor.rs
@@ -65,12 +65,6 @@ impl DepositMonitor {
         utxo: &Utxo,
         chain_tip: &BlockRef,
     ) -> Result<CreateDepositRequestBody, Error> {
-        tracing::debug!(
-            "Processing utxo: txid={}, vout={}, block_height={}",
-            utxo.txid,
-            utxo.vout,
-            utxo.block_height
-        );
         let monitored_deposit = self
             .monitored
             .get(&utxo.script_pub_key)

--- a/src/deposit_monitor.rs
+++ b/src/deposit_monitor.rs
@@ -87,18 +87,9 @@ impl DepositMonitor {
         let cached_hash = self.hashes_cache.get(&utxo.block_height);
         let block_hash = match cached_hash {
             Some(hash) => {
-                tracing::debug!(
-                    "Using cached block hash for utxo at height {}: {}",
-                    utxo.block_height,
-                    hash
-                );
                 *hash
             }
             None => {
-                tracing::debug!(
-                    "Fetching block hash for utxo at height {}",
-                    utxo.block_height
-                );
                 let hash = bitcoin_client.get_block_hash(utxo.block_height)?;
                 self.hashes_cache.put(utxo.block_height, hash);
                 hash
@@ -108,19 +99,9 @@ impl DepositMonitor {
         let cached_tx_hex = self.tx_hex_cache.get(&(utxo.txid, block_hash));
         let tx_hex = match cached_tx_hex {
             Some(hex) => {
-                tracing::debug!(
-                    "Using cached transaction hex for txid {} at block {}",
-                    utxo.txid,
-                    block_hash
-                );
                 hex.clone()
             }
             None => {
-                tracing::debug!(
-                    "Fetching transaction hex for txid {} at block {}",
-                    utxo.txid,
-                    block_hash
-                );
                 let tx_hex = bitcoin_client.get_raw_transaction_hex(&utxo.txid, &block_hash)?;
                 self.tx_hex_cache
                     .put((utxo.txid, block_hash), tx_hex.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ struct Args {
 
 async fn fetch_and_create_deposits(
     context: &Context,
-    deposit_monitor: &DepositMonitor,
+    deposit_monitor: &mut DepositMonitor,
     chain_tip: &BlockRef,
 ) -> Result<(), Error> {
     let emily_config = context.emily_config();
@@ -71,7 +71,11 @@ async fn fetch_and_create_deposits(
     Ok(())
 }
 
-async fn runloop(context: Context, deposit_monitor: &DepositMonitor, polling_interval: Duration) {
+async fn runloop(
+    context: Context,
+    deposit_monitor: &mut DepositMonitor,
+    polling_interval: Duration,
+) {
     let bitcoin_client = context.bitcoin_client();
     let mut last_chain_tip = None;
 
@@ -146,9 +150,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // TODO: load from config
     let monitored = vec![devenv_deposit_address(&args.signers_xonly)];
 
-    let deposit_monitor = DepositMonitor::new(context.clone(), monitored);
+    let mut deposit_monitor = DepositMonitor::new(context.clone(), monitored);
 
-    runloop(context.clone(), &deposit_monitor, config.polling_interval).await;
+    runloop(
+        context.clone(),
+        &mut deposit_monitor,
+        config.polling_interval,
+    )
+    .await;
 
     Ok(())
 }


### PR DESCRIPTION
This PR resolves some TODOs and adds caching of `bitcoin_client.get_raw_transaction_hex` and `bitcoin_client.get_block_hash` calls.

About testing as I see we are in prototype phase and do not test as heavily as in sBTC repo, and to test this I need to implement some mock of bitcoin client which can be not so obvious, so for now I just manually run demo flow and check that everything is okish.