### PR TITLE
feat: load monitored deposits from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 
 sPox can be tested with the sBTC devenv:
  - `make devenv-up`, wait for nakamoto and `./signers.sh demo` to get the signers ready
- - Get signers aggregate key with `cargo run -p signer --bin demo-cli info` (from sBTC)
  - Edit `signer/src/bin/demo_cli.rs`, `exec_deposit` to return after `send_raw_transaction` but before `create_deposit`
  
 Now, in no particular order:
- - Start spox: `cargo run -- -c src/config/default.toml --signers-xonly <signers xonly pubkey from info above>`
+ - Start spox (overwriting the devenv aggregate key; or edit the config with the value returned from `get-signers-pubkey`)
+    ```bash
+    SPOX_DEPOSIT__DEMO__SIGNERS_XONLY=$(RUST_LOG=info cargo run -- -c src/config/default.toml get-signers-pubkey) RUST_LOG=debug cargo run -- -c src/config/default.toml
+    ```
  - Create a deposit (without notifying emily): `cargo run -p signer --bin demo-cli deposit --amount 123456` (from sBTC)
 
 This will look for deposits made to the signers pubkey with the devenv default values. Once the tx is confirmed it should appear on Emily, assuming it didn't expire in the meantime, and be processed by the signers, assuming the amount is not too low to be ignored.

--- a/src/config/default.toml
+++ b/src/config/default.toml
@@ -17,6 +17,20 @@ bitcoin_rpc_endpoint = "http://devnet:devnet@127.0.0.1:18443"
 # polling_interval = 30
 
 # !! ===========================================================================
+# !! Monitored deposits
+# !! ---------------------------------------------------------------------------
+# !! Each `[deposit.<alias>]` is a monitored deposit.
+# !! ===========================================================================
+[deposit.demo]
+# sBTC devenv demo configuration
+# `signers_xonly` has a placeholder value since it's not constant
+signers_xonly = "0000000000000000000000000000000000000000000000000000000000000001"
+recipient = "ST3497E9JFQ7KB9VEHAZRWYKF3296WQZEXBPXG193"
+max_fee = 20000
+lock_time = 10
+reclaim_script = ""
+
+# !! ===========================================================================
 # !! Stacks configuration
 # !! ---------------------------------------------------------------------------
 # !! This stanza is required only to run some CLI commands, otherwise can be

--- a/src/config/serialization.rs
+++ b/src/config/serialization.rs
@@ -1,3 +1,6 @@
+use std::str::FromStr as _;
+
+use bitcoin::{ScriptBuf, XOnlyPublicKey, secp256k1};
 use clarity::types::chainstate::StacksAddress;
 use clarity::vm::types::PrincipalData;
 use serde::{Deserialize, Deserializer};
@@ -41,4 +44,31 @@ where
     PrincipalData::parse_standard_principal(&literal)
         .map(StacksAddress::from)
         .map_err(serde::de::Error::custom)
+}
+
+/// Parse the string into a Stacks PrincipalData.
+pub fn principal_deserializer<'de, D>(des: D) -> Result<PrincipalData, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let literal = <String>::deserialize(des)?;
+    PrincipalData::parse(&literal).map_err(serde::de::Error::custom)
+}
+
+/// Parse the string into a XOnlyPublicKey
+pub fn xonly_deserializer<'de, D>(des: D) -> Result<XOnlyPublicKey, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let literal = <String>::deserialize(des)?;
+    secp256k1::XOnlyPublicKey::from_str(&literal).map_err(serde::de::Error::custom)
+}
+
+/// Parse the string into a ScriptBuf
+pub fn script_deserializer<'de, D>(des: D) -> Result<ScriptBuf, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let literal = <String>::deserialize(des)?;
+    ScriptBuf::from_hex(&literal).map_err(serde::de::Error::custom)
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -59,6 +59,10 @@ pub enum Error {
     #[error(transparent)]
     Reqwest(#[from] reqwest::Error),
 
+    /// sBTC error
+    #[error(transparent)]
+    Sbtc(#[from] sbtc::error::Error),
+
     /// A call to `scantxoutset` failed
     #[error("a call to `scantxoutset` failed")]
     ScanTxOutFailure,


### PR DESCRIPTION
Add monitored deposits to the config (as a map, to enable easier overwriting via env variables).

This can be now tested in devenv with:
```bash
SPOX_DEPOSIT__DEMO__SIGNERS_XONLY=$(RUST_LOG=info cargo run -- -c src/config/default.toml get-signers-pubkey) RUST_LOG=debug cargo run -- -c src/config/default.toml
```
or manually changing the config file with the current signers aggregate key.